### PR TITLE
Issue with pyhpecw7 #14

### DIFF
--- a/pyhpecw7/comware.py
+++ b/pyhpecw7/comware.py
@@ -57,7 +57,7 @@ class HPCOM7(object):
         self.password = kvargs.get('password')
         self.port = kvargs.get('port') or 830
         self.timeout = kvargs.get('timeout') or 30
-        self.ssh_config = kvargs.get('ssh_config', False)
+        self.ssh_config = kvargs.get('ssh_config', None)
         self.staged = []
 
         self._locked = False


### PR DESCRIPTION
Issue with pyhpecw7 #14
The default value for the ssh_config parameter that is passed to ncclient.manager.connect is set to False by HPCOM7. But the default value should be None.